### PR TITLE
Fork issue monkey patch

### DIFF
--- a/lib/scm_router.rb
+++ b/lib/scm_router.rb
@@ -65,7 +65,8 @@ class ScmLibraryStore
   
   def master_fork(name)
     project = name.split('/', 2).last
-    File.read(File.join(REPOS_PATH, project, '.master_fork')).strip
+    File.read(File.join(REPOS_PATH, project, '.master_fork')).strip.split('/').
+      reverse.join('/')
   rescue Errno::ENOENT
     nil
   end


### PR DESCRIPTION
This fixes the problem of displaying the "master fork" of a GitHub repository mentioned in [issue 17](http://github.com/lsegal/rubydoc.info/issues/17). Like guessed there, the problem was related to user / repository names, because the contents of the `.master_fork` files are in reversed order.

It is a small monkey patch not requiring any action on your side. It will fix the `.master_fork` contents on the fly.
