### PR TITLE
Show gem search exact match above all results

### DIFF
--- a/templates/gems_index.erb
+++ b/templates/gems_index.erb
@@ -31,6 +31,23 @@
     <% end %>
   </ul>
 
+  <% if @search && (exact_match = @libraries.find { |k,v| k == @search }) %>
+    <h3>Exact match</h3>
+    <ul class="libraries">
+      <li class="r1">
+        <% library_versions = exact_match[1].dup %>
+        <% first_lib = library_versions.pop %>
+        <a href="#/<%= @adapter.router.docs_prefix %>/<%= first_lib.name %>/frames"><%= exact_match[0] %></a>
+        <% if first_lib && first_lib.version %>
+          <small>(<%= first_lib.version %><% if library_versions.size > 0 %>,
+            <%= library_versions.reverse[0..3].map {|lib| "<a href=\"#/#{@adapter.router.docs_prefix}/#{lib}/frames\">#{lib.version}</a>" }.join(', ') %><% end %>)</small>
+        <% end %>
+      </li>
+    </ul>
+
+    <h3>All matches</h3>
+  <% end %>
+
   <ul class="libraries">
     <% @libraries.sort_by {|name, y| name.downcase }.each do |name, library_versions| %>
     <li class="r<%= @row = @row == 1 ? 2 : 1 %>">


### PR DESCRIPTION
This should resolve #18 and a pet peeve of mine for a while, showing a gem who's name is an exact match to the search query above the main list of results.

I took inspiration from RubyGems.org, showing the exact match in it's own list at the top, then the old, full list underneath.

RubyGems.org:
![](http://f.cl.ly/items/1d0G111W371K2E0g0g3h/Screen%20Shot%202012-12-05%20at%209.08.12%20PM.png)

RubyDoc.info:
![](http://f.cl.ly/items/3Z012n1X2e1j1U1q0b1M/Screen%20Shot%202012-12-05%20at%209.09.17%20PM.png)
