### PR TITLE
Reorder readme steps reflecting that yard is required to bundle gems

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ enhancements are welcome.
 
 Running the doc server locally is easy:
 
-* git clone git://github.com/lsegal/rubydoc.info && cd rubydoc.info
+* git clone git://github.com/lsegal/rubydoc.info
+* git clone git://github.com/lsegal/yard yard (must be one level above the Gemfile)
+* cd rubydoc.info
 * bundle install
 * rake gems:update
-* git clone git://github.com/lsegal/yard yard (optional)
 * rackup config.ru
 
 Contributors


### PR DESCRIPTION
The steps in the readme to get it running locally were outdated and didn't reflect that the Gemfile points to a local copy of yard, so yard must be cloned prior to running `bundle install`.

Yard's been referenced locally for about a year now (see 2d8f6f22) so figured I'd update the steps to be accurate since it tripped me up for a second.
