### PR TITLE
Sequel 4.0.0 compatibility

### DIFF
--- a/lib/recent_store.rb
+++ b/lib/recent_store.rb
@@ -37,6 +37,6 @@ class RecentStore
   end
 
   def each(&block)
-    LibraryStore.select.order(:created_at.desc).limit(@maxsize).all.each(&block)
+    LibraryStore.select.order(Sequel.desc(:created_at)).limit(@maxsize).all.each(&block)
   end
 end


### PR DESCRIPTION
method-on-a-symbol style ordering no longer appears to be supported (failed after a bundle update). This should be backwards compatible as well.
