### PR TITLE
Support for Redcarpet tables extension. 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'yard', :git => 'git://github.com/lsegal/yard'
 gem 'yard-rails'
 gem 'yard-kramdown'
 gem 'yard-sd'
+gem 'yard-redcarpet-ext', '~> 0.0.3'
 gem 'i18n'
 gem 'net-http-persistent', '~> 2.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,8 @@ GEM
     yard-kramdown (0.0.1)
     yard-rails (0.3.0)
       yard
+    yard-redcarpet-ext (0.0.3)
+      yard (~> 0.8.0)
     yard-sd (0.0.4)
 
 PLATFORMS
@@ -102,4 +104,5 @@ DEPENDENCIES
   yard!
   yard-kramdown
   yard-rails
+  yard-redcarpet-ext (~> 0.0.3)
   yard-sd

--- a/init.rb
+++ b/init.rb
@@ -10,6 +10,7 @@ require 'yard'
 require 'yard-sd'
 require 'yard-rails'
 require 'yard-kramdown'
+require 'yard-redcarpet-ext'
 
 YARD::Server::Adapter.setup
 YARD::Templates::Engine.register_template_path(File.dirname(__FILE__) + '/templates')


### PR DESCRIPTION
Tables extension used by default by GitHub.

Some projects already used it with YARD, like `reg.api2` or `active_admin`.
