### PR TITLE
Add support for SSH checkout urls (git@github.com:$user/$project).

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -242,6 +242,11 @@ class DocServer < Sinatra::Base
     def shorten_commit_link(commit)
       commit.slice(0..5)
     end
+
+    def clone_url(username, project)
+      prefix = $CONFIG.use_ssh_clones ? "git@github.com:" : "git://github.com/"
+      "#{prefix}#{username}/#{project}"
+    end
   end
 
   # Filters
@@ -267,7 +272,7 @@ class DocServer < Sinatra::Base
       end
 
       url = url.sub(%r{^http://}, 'git://')
-      if url =~ %r{github\.com/([^/]+)/([^/]+)}
+      if url =~ %r{github\.com[/:]([^/]+)/([^/]+)}
         username, project = $1, $2
         if settings.whitelisted_projects.include?("#{username}/#{project}")
           puts "Dropping safe mode for #{username}/#{project}"

--- a/config/config.yaml.sample
+++ b/config/config.yaml.sample
@@ -9,6 +9,9 @@
 # Whether or not disk caching is enabled. Defaults to false
 # caching: false
 
+# If true, clone repositories using ssh instead of git://.
+# use_ssh_clones: false
+
 # If you have Airbrake, uncomment the following line and add your API key:
 # airbrake: YOUR_API_KEY
 

--- a/lib/scm_checkout.rb
+++ b/lib/scm_checkout.rb
@@ -97,7 +97,8 @@ class GithubCheckout < ScmCheckout
     case url
     when Array
       self.username, self.project = *url
-    when %r{^(?:https?|git)://(?:www\.?)?github\.com/([^/]+)/([^/]+?)(?:\.git)?/?$}
+    when %r{^(?:https?|git)://(?:www\.?)?github\.com/([^/]+)/([^/]+?)(?:\.git)?/?$},
+      %r{^git@github\.com:([^/]+)/([^/]+?)(?:\.git)?/?$}
       self.username, self.project = $1, $2
     else
       raise InvalidSchemeError

--- a/public/js/project_checkout.js
+++ b/public/js/project_checkout.js
@@ -30,7 +30,7 @@ function checkoutForm() {
         if (data == "OK") {
           var arr = url.split('/');
           var dirname = arr[arr.length-1].replace(/\.[^.]+$/, '');
-          var match = url.match(/^(?:git|https?):\/\/(?:www\.)?github\.com\/([^\/]+)/);
+          var match = url.match(/^(?:(?:git|https?):\/\/(?:www\.)?)|(?:git@)github\.com[\/:]([^\/]+)/);
           if (match) {
             var name = match[1];
             dirname = name + '/' + dirname + '/' +

--- a/templates/checkout.erb
+++ b/templates/checkout.erb
@@ -3,9 +3,9 @@
 </style>
 <div id="checkout">
   <h2>Add your own project</h2>
-  <small class="example">(eg. git://github.com/lsegal/yard.git)</small>
+  <small class="example">(eg. <%= clone_url('lsegal', 'yard') %>)</small>
   <form id="checkout_form" action="/checkout" method="post">
-    <input class="url" type="text" id="url" name="url" placeholder="git://github.com/username/project" />
+    <input class="url" type="text" id="url" name="url" placeholder="<%= clone_url('username', 'project') %>" />
     <div class="loadicon"></div>
     <input type="hidden" id="scheme" name="scheme" value="git" />
     <br/>

--- a/templates/layout.erb
+++ b/templates/layout.erb
@@ -70,7 +70,7 @@
       function reloadProject() {
         $('.libraries .project_reload').click(function() {
           var proj = $(this).parent().find('a:first-child').text();
-          $('#url').val("git://github.com/" + proj);
+          $('#url').val("<%= $CONFIG.use_ssh_clones ? "git@github.com:" : "git://" %>" + proj);
           $('#commit').val('');
           $('#checkout_form').submit();
           $(this).find('img').attr('src', '/images/loading.gif');

--- a/templates/scm_404.erb
+++ b/templates/scm_404.erb
@@ -8,7 +8,7 @@
     <p>We haven't generated any docs for <strong><%= @username %>/<%= @project %></strong>. You can add the project yourself by entering the Github project information below.
       You can also see a list of available projects <a href="/github">here</a>.</p>
     <script type="text/javascript" charset="utf-8">
-      $(function() { $('#url').val('git://github.com/<%= @username %>/<%= @project %>'); });
+      $(function() { $('#url').val('<%= clone_url(@username, @project) %>'); });
     </script>
 
     <%= erb :checkout, :layout => false %>


### PR DESCRIPTION
This can be useful for running an internal rubydoc.info instance
against a set of private repositories.

Add a config option to determine whether internally-generated URLs use
ssh or git://
