### PR TITLE
Allow overriding data paths in config

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -185,10 +185,12 @@ class DocServer < Sinatra::Base
 
   configure(:production) do
     enable :logging
-    # log to file
-    file = File.open(File.join(LOG_PATH, "sinatra.log"), "a")
-    STDOUT.reopen(file)
-    STDERR.reopen(file)
+    unless $CONFIG.log_to_stdout
+      # log to file
+      file = File.open(File.join(LOG_PATH, "sinatra.log"), "a")
+      STDOUT.reopen(file)
+      STDERR.reopen(file)
+    end
   end
 
   configure do

--- a/app.rb
+++ b/app.rb
@@ -186,7 +186,7 @@ class DocServer < Sinatra::Base
   configure(:production) do
     enable :logging
     # log to file
-    file = File.open("log/sinatra.log", "a")
+    file = File.open(File.join(LOG_PATH, "sinatra.log"), "a")
     STDOUT.reopen(file)
     STDERR.reopen(file)
   end

--- a/app.rb
+++ b/app.rb
@@ -64,10 +64,14 @@ class DocServer < Sinatra::Base
 
   def self.copy_static_files
     # Copy template files
-    puts ">> Copying static system files..."
+    puts ">> Copying static files..."
+    unless File.realpath(PUBLIC_PATH) == File.realpath(STATIC_PATH)
+      FileUtils.cp_r(PUBLIC_PATH + "/.", STATIC_PATH)
+    end
+
     YARD::Templates::Engine.template(:default, :fulldoc, :html).full_paths.each do |path|
       %w(css js images).each do |ext|
-        srcdir, dstdir = File.join(path, ext), File.join('public', ext)
+        srcdir, dstdir = File.join(path, ext), File.join(STATIC_PATH, ext)
         next unless File.directory?(srcdir)
         system "mkdir -p #{dstdir} && cp #{srcdir}/* #{dstdir}/"
       end

--- a/config/config.yaml.sample
+++ b/config/config.yaml.sample
@@ -9,6 +9,9 @@
 # Whether or not disk caching is enabled. Defaults to false
 # caching: false
 
+# Whether to send logs to stdout in production (instead of log/sinatra.log)
+# log_to_stdout: true
+
 # If you have Airbrake, uncomment the following line and add your API key:
 # airbrake: YOUR_API_KEY
 

--- a/init.rb
+++ b/init.rb
@@ -18,26 +18,36 @@ YARD::Templates::Engine.register_template_path(File.dirname(__FILE__) + '/templa
 def __p(*extra)
   file = extra.last == :file
   extra.pop if file
-  path = File.join(File.dirname(__FILE__), *extra)
+
+  conf = $CONFIG.paths
+  while !extra.empty? && conf.is_a?(Hash) && conf.key?(extra.first)
+    conf = conf[extra.shift]
+  end
+
+  root = conf.is_a?(String) ? conf : File.dirname(__FILE__)
+  path = File.join(root, *extra)
   FileUtils.mkdir_p(path) unless File.exists?(path) || file
   path
 end
 
-CONFIG_PATH      = __p('config')
+require_relative 'lib/configuration'
+
+CONFIG_FILE      = File.join(File.dirname(__FILE__), 'config/config.yaml')
+
+$CONFIG = Configuration.load(CONFIG_FILE)
+
+PUBLIC_PATH      = File.join(File.dirname(__FILE__), 'public')
 STATIC_PATH      = __p('public')
-REPOS_PATH       = __p('repos/github')
-REMOTE_GEMS_PATH = __p('repos/gems')
-STDLIB_PATH      = __p('repos/stdlib')
-FEATURED_PATH    = __p('repos/featured')
+REPOS_PATH       = __p('repos', 'github')
+REMOTE_GEMS_PATH = __p('repos', 'gems')
+STDLIB_PATH      = __p('repos', 'stdlib')
+FEATURED_PATH    = __p('repos', 'featured')
 TMP_PATH         = __p('tmp')
 DATA_PATH        = __p('data')
 TEMPLATES_PATH   = __p('templates')
-CONFIG_FILE      = __p('config', 'config.yaml', :file)
 REMOTE_GEMS_FILE = __p('data', 'remote_gems', :file)
 RECENT_SQL_FILE  = __p('data', 'recent.sqlite', :file)
 
 require_relative 'lib/helpers'
 require_relative 'lib/cache'
-require_relative 'lib/configuration'
 
-$CONFIG = Configuration.load

--- a/init.rb
+++ b/init.rb
@@ -37,6 +37,7 @@ CONFIG_FILE      = File.join(File.dirname(__FILE__), 'config/config.yaml')
 $CONFIG = Configuration.load(CONFIG_FILE)
 
 PUBLIC_PATH      = File.join(File.dirname(__FILE__), 'public')
+LOG_PATH         = __p('log')
 STATIC_PATH      = __p('public')
 REPOS_PATH       = __p('repos', 'github')
 REMOTE_GEMS_PATH = __p('repos', 'gems')

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -1,9 +1,9 @@
 class Configuration < Hash
-  def self.load
+  def self.load(path=CONFIG_FILE)
     config = Configuration.new
 
-    if File.file?(CONFIG_FILE)
-      YAML.load_file(CONFIG_FILE).each do |key, value|
+    if File.file?(path)
+      YAML.load_file(path).each do |key, value|
         config[key] = value
         define_method(key) { self[key] }
       end

--- a/lib/recent_store.rb
+++ b/lib/recent_store.rb
@@ -1,7 +1,7 @@
 require 'sequel'
 require 'base64'
 
-DB = Sequel.sqlite('recent.sqlite')
+DB = Sequel.sqlite(RECENT_SQL_FILE)
 unless DB.table_exists?(:library_stores)
   DB.create_table(:library_stores) do
     primary_key :id


### PR DESCRIPTION
The goal of this PR is to enable rubydoc.info to run without any write access to the code directory in production. This is useful for many deploy environments, and allows e.g. seamless upgrades by having multiple checkouts of different versions to share data, and seamlessly switching between them.
