### PR TITLE
Fix about overlay

### DIFF
--- a/templates/layout.erb
+++ b/templates/layout.erb
@@ -117,7 +117,7 @@
       <li><a id="about" href="#">About</a></li>
     <% if defined? settings.tender %><li><a id="help" href="#">Help</a></li><% end %>
     </ul>
-    <a id="help_tender" href="#" style="display:none;"/>
+    <a id="help_tender" href="#" style="display:none;"></a>
     <div class="clear"></div>
 
     <div id="info">


### PR DESCRIPTION
Just noticed this (in Firefox & Chrome): If you click on the "About" link in the navigation, the appearing text should read something like "[...] This site uses YARD to ...", but what it actually reads is:

![rubydoc-info](https://cloud.githubusercontent.com/assets/311914/2665122/87ffa7a6-c089-11e3-9c42-9a30587c4057.png)

This PR is fixing the corresponding HTML.
