### PR TITLE
Can you please add yard-ruby-hooks plugin support 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'yard-rails'
 gem 'yard-kramdown'
 gem 'yard-sd'
 gem 'yard-redcarpet-ext', '~> 0.0.3'
+gem 'yard-ruby-hooks', '~>1.0'
 gem 'i18n'
 gem 'net-http-persistent', '~> 2.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ GEM
       yard
     yard-redcarpet-ext (0.0.3)
       yard (~> 0.8.0)
+    yard-ruby-hooks (1.0.1)
     yard-sd (0.0.4)
 
 PLATFORMS
@@ -96,4 +97,5 @@ DEPENDENCIES
   yard-kramdown
   yard-rails
   yard-redcarpet-ext (~> 0.0.3)
+  yard-ruby-hooks (~> 1.0)
   yard-sd

--- a/init.rb
+++ b/init.rb
@@ -11,6 +11,7 @@ require 'yard-sd'
 require 'yard-rails'
 require 'yard-kramdown'
 require 'yard-redcarpet-ext'
+require 'yard-ruby-hooks'
 
 YARD::Server::Adapter.setup
 YARD::Templates::Engine.register_template_path(File.dirname(__FILE__) + '/templates')


### PR DESCRIPTION
the repository is here: https://github.com/remote-exec/yard-ruby-hooks
and the gem here: https://rubygems.org/gems/yard-ruby-hooks
I was not sure if it should be added in Gemfile or somewhere else, will gladly upgrade to PR if you point out where to add it
