### PR TITLE
Allow ssh git links to be used.

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -272,7 +272,7 @@ class DocServer < Sinatra::Base
       url = (url || '').sub(%r{^http://}, 'git://')
       commit ||= nil
 
-      if url =~ %r{github\.com/([^/]+)/([^/]+)}
+      if url =~ %r{github\.com[/:]([^/]+)/([^/]+)}
         username, project = $1, $2
         if settings.whitelisted_projects.include?("#{username}/#{project}")
           puts "Dropping safe mode for #{username}/#{project}"

--- a/lib/scm_checkout.rb
+++ b/lib/scm_checkout.rb
@@ -97,7 +97,8 @@ class GithubCheckout < ScmCheckout
     case url
     when Array
       self.username, self.project = *url
-    when %r{^(?:https?|git)://(?:www\.?)?github\.com/([^/]+)/([^/]+?)(?:\.git)?/?$}
+    when %r{^(?:https?|git)://(?:www\.?)?github\.com/([^/]+)/([^/]+?)(?:\.git)?/?$},
+      %r{^git@github\.com:([^/]+)/([^/]+?)(?:\.git)?/?$}
       self.username, self.project = $1, $2
     else
       raise InvalidSchemeError

--- a/public/js/project_checkout.js
+++ b/public/js/project_checkout.js
@@ -30,7 +30,7 @@ function checkoutForm() {
         if (data == "OK") {
           var arr = url.split('/');
           var dirname = arr[arr.length-1].replace(/\.[^.]+$/, '');
-          var match = url.match(/^(?:git|https?):\/\/(?:www\.)?github\.com\/([^\/]+)/);
+          var match = url.match(/^(?:git:\/\/|https:\/\/|git@?)(?:www\.)?github\.com[\/|:]([^\/]+)|(?:git@)github\.com[\/:]([^\/]+)/);
           if (match) {
             var name = match[1];
             dirname = name + '/' + dirname + '/' +

--- a/spec/github_checkout_spec.rb
+++ b/spec/github_checkout_spec.rb
@@ -21,6 +21,13 @@ describe GithubCheckout do
       end
     end
 
+    it "should accept ssh style github urls" do
+      git("git@github.com:reevoo/stratocumulus.git")
+      @git.username.should == "reevoo"
+      @git.project.should == "stratocumulus"
+      @git.name.should == "reevoo/stratocumulus"
+    end
+
     it "should accept github URLs with ending in .git" do
       git("git://github.com/lsegal/yard.git")
       @git.username.should == "lsegal"

--- a/templates/checkout.erb
+++ b/templates/checkout.erb
@@ -3,9 +3,9 @@
 </style>
 <div id="checkout">
   <h2>Add your own project</h2>
-  <small class="example">(eg. git@github.com:lsegal/yard.git or https://github.com/lsegal/yard.git)</small>
+  <small class="example">(eg. https://github.com/lsegal/yard.git)</small>
   <form id="checkout_form" action="/checkout" method="post">
-    <input class="url" type="text" id="url" name="url" placeholder="git@github.com/username/project" />
+    <input class="url" type="text" id="url" name="url" placeholder="https://github.com/username/project" />
     <div class="loadicon"></div>
     <input type="hidden" id="scheme" name="scheme" value="git" />
     <br/>

--- a/templates/checkout.erb
+++ b/templates/checkout.erb
@@ -3,9 +3,9 @@
 </style>
 <div id="checkout">
   <h2>Add your own project</h2>
-  <small class="example">(eg. git://github.com/lsegal/yard.git)</small>
+  <small class="example">(eg. git@github.com:lsegal/yard.git or https://github.com/lsegal/yard.git)</small>
   <form id="checkout_form" action="/checkout" method="post">
-    <input class="url" type="text" id="url" name="url" placeholder="git://github.com/username/project" />
+    <input class="url" type="text" id="url" name="url" placeholder="git@github.com/username/project" />
     <div class="loadicon"></div>
     <input type="hidden" id="scheme" name="scheme" value="git" />
     <br/>

--- a/templates/layout.erb
+++ b/templates/layout.erb
@@ -56,7 +56,7 @@
       function reloadProject() {
         $('.libraries .project_reload').click(function() {
           var proj = $(this).parent().find('a:first-child').text();
-          $('#url').val("git://github.com/" + proj);
+          $('#url').val("git@github.com:" + proj);
           $('#commit').val('');
           $('#checkout_form').submit();
           $(this).find('img').attr('src', '/images/loading.gif');

--- a/templates/layout.erb
+++ b/templates/layout.erb
@@ -56,7 +56,7 @@
       function reloadProject() {
         $('.libraries .project_reload').click(function() {
           var proj = $(this).parent().find('a:first-child').text();
-          $('#url').val("git@github.com:" + proj);
+          $('#url').val("https://github.com/" + proj);
           $('#commit').val('');
           $('#checkout_form').submit();
           $(this).find('img').attr('src', '/images/loading.gif');

--- a/templates/scm_404.erb
+++ b/templates/scm_404.erb
@@ -8,7 +8,7 @@
     <p>We haven't generated any docs for <strong><%= h @username %>/<%= h @project %></strong>. You can add the project yourself by entering the GitHub project information below.
       You can also see a list of available projects <a href="/github">here</a>.</p>
     <script type="text/javascript" charset="utf-8">
-      $(function() { $('#url').val('git://github.com/<%= h @username %>/<%= h @project %>'); });
+      $(function() { $('#url').val('https://github.com/<%= h @username %>/<%= h @project %>'); });
     </script>
 
     <%= erb :checkout, :layout => false %>


### PR DESCRIPTION
Links in the form of `git@github.com:lsegal/yard.git`
are now the default on github so it makes sense to
have the example in that format too.

Supporting SSH links makes running a private instance
nicer.

Mostly a duplication of #71 but drops the config
switch stuff in favour of just using the ssh format
everywhere.
