### PR TITLE
Fixes GitHub links

### DIFF
--- a/templates/default/fulldoc/html/js/rubydoc_custom.js
+++ b/templates/default/fulldoc/html/js/rubydoc_custom.js
@@ -1,7 +1,7 @@
 function createGithubLinks() {
-  if (match = window.location.pathname.match(/^\/github\/([^\/]+\/[^/]+)\/([^/]+)/)) {
+  if (match = window.location.pathname.match(/^\/github\/([^\/]+\/[^/]+)\/(?:[^/]+)/)) {
     var github_project = match[1];
-    var github_commit = match[2];
+    var github_commit = $('#menu .title small').text().replace(/^\(|\)\s*$/g, '');
 
     $(".source_code").each( function() {
        if (match = $(this).find(".info.file").text().match(/^# File '([^']+)', line (\d+)/)) {


### PR DESCRIPTION
Link "View on GitHub" ends up on a 404 page due to ~~change in GitHub's URL structure. `/blob/` changed to `/tree/` is all~~ a false assumption that the version would be in the rubydoc.info url. Since it's not, I've made it pull that value from the page content instead.

Also includes #102 because I couldn't run it locally without that change. Feel free to rebase it out.
