### PR TITLE
Allow gem source to be configured

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,7 +29,7 @@ namespace :server do
 end
 
 namespace :gems do
-  desc 'Update gem list from Rubygems.org'
+  desc 'Update gem list from remote'
   task :update do
     puts ">> Updating Remote Gems file (local cache)"
     load('scripts/update_remote_gems.rb')

--- a/config/config.yaml.sample
+++ b/config/config.yaml.sample
@@ -63,3 +63,6 @@
 #
 # disallowed_gems:
 #   - gemname
+
+# Custom gem server
+# gem_source: https://rubygems.org/

--- a/lib/extensions.rb
+++ b/lib/extensions.rb
@@ -52,7 +52,8 @@ module YARD
 
         # Remote gemfile from rubygems.org
         suffix = platform ? "-#{platform}" : ""
-        url = "http://rubygems.org/downloads/#{to_s(false)}#{suffix}.gem"
+        base_url = ($CONFIG.gem_source || 'http://rubygems.org').gsub(%r(/$), '')
+        url = "#{base_url}/gems/#{to_s(false)}#{suffix}.gem"
         puts "#{Time.now}: Downloading remote gem file #{url}"
 
         FileUtils.mkdir_p(source_path)

--- a/lib/gem_updater.rb
+++ b/lib/gem_updater.rb
@@ -23,13 +23,19 @@ class GemUpdater
 
   class << self
     def fetch_remote_gems
+      spec_fetcher = if $CONFIG.gem_source
+        Gem::SpecFetcher.new(Gem::SourceList.from([Gem::Source.new($CONFIG.gem_source)]))
+      else
+        Gem::SpecFetcher.fetcher
+      end
+
       libs = {}
       if Gem::VERSION < '2.0'
-        Gem::SpecFetcher.fetcher.list(true).values.flatten(1).each do |info|
+        spec_fetcher.list(true).values.flatten(1).each do |info|
           (libs[info[0]] ||= []) << GemVersion.new(*info)
         end
       else # RubyGems 2.x API
-        Gem::SpecFetcher.fetcher.available_specs(:released).first.values.flatten(1).each do |tuple|
+        spec_fetcher.available_specs(:released).first.values.flatten(1).each do |tuple|
           (libs[tuple.name] ||= []) << GemVersion.new(tuple.name, tuple.version, tuple.platform)
         end
       end


### PR DESCRIPTION
This enables a self-hosted copy of rubydoc.info to pull gems from a source other than rubygems.org.

This at least partially addresses #81.
