### PR TITLE
Escape paths with spaces

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -19,6 +19,7 @@ require 'recent_store'
 require 'digest/sha2'
 require 'rack/etag'
 require 'version_sorter'
+require 'shellwords'
 
 class Hash; alias blank? empty? end
 class NilClass; def blank?; true end end
@@ -73,9 +74,10 @@ class DocServer < Sinatra::Base
     puts ">> Copying static system files..."
     YARD::Templates::Engine.template(:default, :fulldoc, :html).full_paths.each do |path|
       %w(css js images).each do |ext|
-        srcdir, dstdir = File.join(path, ext), File.join('public', ext)
-        next unless File.directory?(srcdir)
-        system "mkdir -p #{dstdir} && cp #{srcdir}/* #{dstdir}/"
+        source_dir = Shellwords.shellescape(File.join(path, ext))
+        dest_dir = Shellwords.shellescape(File.join('public', ext).shellescape)
+        next unless File.directory?(source_dir)
+        system "mkdir -p #{dest_dir} && cp #{source_dir}/* #{dest_dir}/"
       end
     end
   end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,6 +1,8 @@
 #!/usr/bin/env puma
 
-root = File.dirname(__FILE__) + '/../'
+require "shellwords"
+
+root = File.expand_path("..", Dir.pwd)
 
 directory root
 rackup root + 'config.ru'
@@ -9,7 +11,9 @@ bind 'tcp://0.0.0.0:8080'
 daemonize unless ENV['DOCKERIZED']
 pidfile root + 'tmp/pids/server.pid'
 unless ENV['DOCKERIZED']
-  stdout_redirect root + 'log/puma.log', root + 'log/puma.err.log', true
+  log = Shellwords.shellescape(File.join(root, 'log/puma.log'))
+  error_log = Shellwords.shellescape(File.join(root, 'log/puma.err.log'))
+  stdout_redirect log, error_log, true
 end
 threads 8, 32
 workers 3


### PR DESCRIPTION
Unlucky folks like me who decided to use iCloud for development may find
themselves with full paths to directories under the following symlinked
directory:

`/Users/olivierlacan/Library/Mobile Documents/com~apple~CloudDocs`

Since Apple brilliantly decided to add spaces to their internal iCloud-synced
directories, some of my development directories (although symlinked) return
this as their base path, which breaks when fed without any escaping to a
`system` call using an interpolated string. The space ends up making the
path look like two different arguments.

In this case, it broke `rackup config.ru` for me since
DocServer.copy_static_files attempts to copy a few directories to public/

I understand it's a fairly niche concern, but it's possible one other human
may run into this in the next... oh, 15/20 years. Assuming iCloud is still
around by then. :-D

Note: this issue only occurs with methods that take multiple arguments