### PR TITLE
Simplify stack

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -84,10 +84,12 @@ end
 namespace :docker do
   desc 'Builds documentation for SOURCE in an isolated Docker container'
   task :doc do
-    dir = File.join(__dir__, "docker", "docparse")
-    if `docker images -q docparse:latest 2> /dev/null`.strip == ""
-      sh "docker build -q -t docparse docker/docparse >/dev/null"
+    source_path = ENV['SOURCE']
+    host_path_file = File.join(__dir__, 'data', 'host_path')
+    if File.exist?(host_path_file)
+      source_path = source_path.sub(/\A\/app/, File.read(host_path_file).strip)
     end
-    sh "docker run --rm -v #{dir.inspect}:/rb:ro -v #{ENV['SOURCE'].inspect}:/build docparse /rb/generate.rb"
+
+    sh "docker run --rm -v #{source_path.inspect}:/build 127.0.0.1:5000/rubydoc-docparse"
   end
 end

--- a/config/config.yaml.sample
+++ b/config/config.yaml.sample
@@ -74,3 +74,6 @@ skylight_token: YOUR_AUTH_TOKEN
 
 # Custom gem server
 # gem_source: https://rubygems.org/
+
+# Disable gem hosting
+# disable_gems: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,23 @@
-version: "2.4"
+version: "3.7"
 services:
   app:
-    privileged: true
+    image: 127.0.0.1:5000/rubydoc-app
     build:
       context: .
       dockerfile: ./docker/app/Dockerfile
     volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./config:/app/config
       - ./repos:/app/repos
       - ./data:/app/data
       - ./log:/app/log
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "512k"
-        max-file: "3"
     ports:
       - "80:8080"
+  docparse:
+    image: 127.0.0.1:5000/rubydoc-docparse
+    build:
+      context: ./docker/docparse
+    entrypoint: sh -c "echo Docparse image is built. It is okay for this service to exit."
   # cache:
   #   build:
   #     context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,12 +13,21 @@ services:
       - ./log:/app/log
     ports:
       - "80:8080"
+    deploy:
+      replicas: 4
+    depends_on:
+      - docparse
   docparse:
     image: 127.0.0.1:5000/rubydoc-docparse
     build:
       context: ./docker/docparse
     entrypoint: sh -c "echo Docparse image is built. It is okay for this service to exit."
+    deploy:
+      replicas: 0
+      restart_policy:
+        condition: none
   # cache:
+  #   image: 127.0.0.1:5000/rubydoc-cache
   #   build:
   #     context: .
   #     dockerfile: ./docker/cache/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       - "80:8080"
     deploy:
       replicas: 4
+      update_config:
+        parallelism: 2
     depends_on:
       - docparse
   docparse:

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,8 +1,11 @@
 FROM ruby:2.6-alpine
 LABEL Maintainer="Loren Segal <lsegal@soen.ca>"
 
-RUN apk add --no-cache -U dcron docker git sqlite-dev build-base
+RUN apk add --no-cache -U docker git sqlite-dev build-base
 RUN gem update --no-document --system
+
+RUN touch /var/run/docker.sock
+RUN chown root:docker /var/run/docker.sock
 
 RUN adduser -D app
 RUN sed -E -i 's/^(docker:.+)/\1app/' /etc/group
@@ -17,7 +20,8 @@ RUN gem install bundler
 ADD --chown=app:app ./Gemfile /app/Gemfile
 ADD --chown=app:app ./Gemfile.lock /app/Gemfile.lock
 WORKDIR /app
-RUN bundle --without test --path vendor/bundle
+RUN bundle config set without 'test'
+RUN bundle install
 
 LABEL docmeta.rubydoc=true
 ENV DOCKERIZED=1
@@ -25,10 +29,4 @@ ENV DOCKERIZED=1
 # Rest of app
 ADD --chown=app:app . /app
 
-# Install cron script
-USER root
-COPY ./docker/app/update-gems /etc/periodic/15min/
-RUN chmod a+x /etc/periodic/15min/update-gems
-
-# Command as root but don't worry, we switch back to app!
 ENTRYPOINT [ "sh", "/app/docker/app/entrypoint.sh" ]

--- a/docker/app/entrypoint.sh
+++ b/docker/app/entrypoint.sh
@@ -1,21 +1,3 @@
 #!/bin/sh
 
-rm -f /var/run/docker.pid
-dockerd &>/var/log/docker.log &
-
-tries=0
-d_timeout=60
-until docker info >/dev/null 2>&1
-do
-	if [ "$tries" -gt "$d_timeout" ]; then
-    cat /var/log/docker.log
-		echo 'Timed out trying to connect to internal docker host.' >&2
-		exit 1
-	fi
-  tries=$(( $tries + 1 ))
-	sleep 1
-done
-
-crond -b -d -L /var/log/crond.log &
-su app sh -c 'docker build -q -t docparse docker/docparse' &
-su app sh -c 'bundle exec rake gems:update server:start'
+bundle exec rake server:start

--- a/docker/app/update-gems
+++ b/docker/app/update-gems
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-cd /app
-su app sh -c "bundle exec rake gems:update cache:clean_index"

--- a/docker/docparse/Dockerfile
+++ b/docker/docparse/Dockerfile
@@ -1,9 +1,13 @@
 FROM ruby:2.6-alpine
+
+ADD ./generate.rb /rb/generate.rb
+RUN chmod +x /rb/generate.rb
+
 RUN adduser -D app
-RUN sed -E -i 's/^(docker:.+)/\1app/' /etc/group
 USER app
 ENV GEM_HOME /home/app/.gem/ruby/2.6.0
 RUN gem update --system --no-document
 RUN gem install --no-document bundler yard
 WORKDIR /build
-ENTRYPOINT ["ruby"]
+
+ENTRYPOINT ["/rb/generate.rb"]

--- a/lib/gem_updater.rb
+++ b/lib/gem_updater.rb
@@ -43,7 +43,7 @@ class GemUpdater
       libs
     end
 
-    def update_remote_gems
+    def update_remote_gems(display: false)
       libs = fetch_remote_gems
       store = GemStore.new
       changed_gems = {}
@@ -76,7 +76,21 @@ class GemUpdater
         store.delete(gem_name)
       end
 
-      [changed_gems, removed_gems]
+      result = [changed_gems, removed_gems]
+
+      if display
+        if changed_gems.size > 0
+          puts ">> Updated #{changed_gems.size} gems:"
+          puts changed_gems.keys.join(', ')
+        end
+
+        if removed_gems.size > 0
+          puts ">> Removed #{removed_gems.size} gems:"
+          puts removed_gems.join(', ')
+        end
+      end
+
+      result
     end
 
     def pick_best_versions(versions)

--- a/scripts/puma.rb
+++ b/scripts/puma.rb
@@ -12,4 +12,4 @@ unless ENV['DOCKERIZED']
   stdout_redirect root + 'log/puma.log', root + 'log/puma.err.log', true
 end
 threads 4, 16
-workers 4
+workers 1

--- a/scripts/puma.rb
+++ b/scripts/puma.rb
@@ -11,5 +11,5 @@ pidfile root + 'tmp/pids/server.pid'
 unless ENV['DOCKERIZED']
   stdout_redirect root + 'log/puma.log', root + 'log/puma.err.log', true
 end
-threads 2, 8
-workers 5
+threads 4, 16
+workers 4

--- a/scripts/setup_host_path.rb
+++ b/scripts/setup_host_path.rb
@@ -1,0 +1,6 @@
+require 'fileutils'
+
+FileUtils.mkdir_p(__dir__ + '/../data')
+File.open(__dir__ + '/../data/host_path', 'w') do |f|
+  f.puts File.expand_path(__dir__ + '/..').gsub(/\A([A-Z]):/, '/\1')
+end

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+cd $(dirname $0)/..
 ruby scripts/setup_host_path.rb
 chown root:docker /var/run/docker.sock 2>/dev/null
 docker swarm init 2>/dev/null

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 
 ruby scripts/setup_host_path.rb
-docker-compose up -d
+chown root:docker /var/run/docker.sock 2>/dev/null
+docker swarm init 2>/dev/null
+docker-compose build
+docker stack deploy --compose-file docker-compose.yml rubydoc

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 
+ruby scripts/setup_host_path.rb
 docker-compose up -d

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -3,5 +3,4 @@
 set -e
 
 git pull
-docker-compose build
-docker-compose restart app
+$(dirname $0)/start.sh

--- a/scripts/update_remote_gems.rb
+++ b/scripts/update_remote_gems.rb
@@ -1,13 +1,4 @@
 #!/bin/env ruby
 require_relative '../lib/gem_updater'
 
-changed_gems, removed_gems = *GemUpdater.update_remote_gems
-if changed_gems.size > 0
-  puts ">> Updated #{changed_gems.size} gems:"
-  puts changed_gems.keys.join(', ')
-end
-
-if removed_gems.size > 0
-  puts ">> Removed #{removed_gems.size} gems:"
-  puts removed_gems.join(', ')
-end
+GemUpdater.update_remote_gems display: true


### PR DESCRIPTION
- Remove dind (use docker socket instead)
- Remove crond from app (use timer Thread)
- Tune puma thread/worker settings
- Add docparse to compose so it is built first
- Reduce startup time on app

The big takeaway is that privileged mode is no longer required to
run the app, and the app starts up much faster. This allows us to
move to docker swarm for orchestration for rolling updates.

Requires running scripts/setup_host_path.rb before running app.
This is handled by scripts/start.sh