### PR TITLE
Add support for gem_source with basic auth

### DIFF
--- a/lib/extensions.rb
+++ b/lib/extensions.rb
@@ -68,7 +68,14 @@ module YARD
 
         Thread.new do
           begin
-            URI.open(url) do |io|
+            uri = URI(url)
+            credentials = uri.user, uri.password
+            uri.user, uri.password = nil
+
+            options = {}
+            options[:http_basic_authentication] = credentials if credentials.any?
+
+            URI.open(uri.to_s, **options) do |io|
               expand_gem(io)
               generate_yardoc(safe_mode)
               clean_source(safe_mode)


### PR DESCRIPTION
`URI.open` doesn't support url with basic auth credentials (i.e.
`https://user@gemsource.com`) and will fail if passed such a url.

It does support passing basic auth credentials via the
`http_basic_authentication:` option though! 😄 

This can be useful for running `rubydoc.info` off of a private gem
server.