### PR TITLE
Documentation: adding a step to copy config.yml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Running the doc server locally is easy:
 git clone git://github.com/lsegal/rubydoc.info
 cd rubydoc.info
 bundle install
+mv config/config.yaml.sample config/config.yaml
 bundle exec rake gems:update
 bundle exec rake server:start
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Running the doc server locally is easy:
 git clone git://github.com/lsegal/rubydoc.info
 cd rubydoc.info
 bundle install
-mv config/config.yaml.sample config/config.yaml
+cp config/config.yaml.sample config/config.yaml
 bundle exec rake gems:update
 bundle exec rake server:start
 ```


### PR DESCRIPTION
Small adjustment to documentation, it seems like step to copy configuration example file is missing.