### PR TITLE
Chore: Yarn gem was yanked, use updated one

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/lsegal/yard.git
-  revision: e21c9323bba88c841a917d0531281b90f27f2378
+  revision: e167846322cacdcecb12cbd438aee9e78c6873a2
   branch: main
   specs:
-    yard (0.9.26)
+    yard (0.9.28)
       webrick (~> 1.7.0)
 
 GEM


### PR DESCRIPTION
I've noticed, that yarn version is yanked from rubygems. So decided to update this dependency, so project could be ran without issues.

![Screenshot from 2022-09-05 00-11-27](https://user-images.githubusercontent.com/544377/188325615-f650b1fd-15cd-4d27-8df8-ad623cd9b981.png)
