### PR TITLE
Remove puma daemonize mode, not supported anymore

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ end
 
 group :framework do
   gem 'sinatra', '>= 1.3'
-  gem 'puma'
+  gem 'puma', '4.3.12'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ end
 
 group :framework do
   gem 'sinatra', '>= 1.3'
-  gem 'puma', '4.3.12'
+  gem 'puma'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
       ruby2_keywords (~> 0.0.1)
     net-http-persistent (2.9.4)
     nio4r (2.5.8)
-    puma (4.3.12)
+    puma (5.6.5)
       nio4r (~> 2.0)
     rack (2.2.3.1)
     rack-mini-profiler (2.3.3)
@@ -122,7 +122,7 @@ DEPENDENCIES
   maruku
   memory_profiler
   net-http-persistent (~> 2.0)
-  puma (= 4.3.12)
+  puma
   rack-mini-profiler
   rack-test
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
       ruby2_keywords (~> 0.0.1)
     net-http-persistent (2.9.4)
     nio4r (2.5.8)
-    puma (5.6.4)
+    puma (4.3.12)
       nio4r (~> 2.0)
     rack (2.2.3.1)
     rack-mini-profiler (2.3.3)
@@ -122,7 +122,7 @@ DEPENDENCIES
   maruku
   memory_profiler
   net-http-persistent (~> 2.0)
-  puma
+  puma (= 4.3.12)
   rack-mini-profiler
   rack-test
   rake

--- a/README.md
+++ b/README.md
@@ -23,11 +23,7 @@ bundle exec rake gems:update
 bundle exec rake server:start
 ```
 
-This will start a daemonized process, you can stop the server with:
-
-```sh
-bundle exec rake server:stop
-```
+You can access application page at http://localhost:8080/ now. 
 
 ### Running With Docker
 

--- a/Rakefile
+++ b/Rakefile
@@ -21,11 +21,6 @@ namespace :server do
   task :restart => 'cache:clean_index' do
     sh "kill -USR1 `cat tmp/pids/server.pid`"
   end
-
-  desc 'Shut down the server'
-  task :stop do
-    sh "kill -9 `cat tmp/pids/server.pid`"
-  end
 end
 
 namespace :gems do

--- a/scripts/puma.rb
+++ b/scripts/puma.rb
@@ -6,7 +6,6 @@ directory root
 rackup root + 'config.ru'
 environment 'production'
 bind 'tcp://0.0.0.0:8080'
-daemonize unless ENV['DOCKERIZED']
 pidfile root + 'tmp/pids/server.pid'
 unless ENV['DOCKERIZED']
   stdout_redirect root + 'log/puma.log', root + 'log/puma.err.log', true


### PR DESCRIPTION
Daemonization was removed from puma in 5.x version, so for this project to work locally - I had to lock puma to last 4.x version.


Here is an error i'm receiving when I try to run this locally:
```
> bundle exec rake server:start
>> Removing index cache pages
Traceback (most recent call last):
	14: from /home/stas/.rvm/gems/ruby-2.7.4/bin/ruby_executable_hooks:22:in `<main>'
	13: from /home/stas/.rvm/gems/ruby-2.7.4/bin/ruby_executable_hooks:22:in `eval'
	12: from /home/stas/.rvm/gems/ruby-2.7.4/bin/puma:23:in `<main>'
	11: from /home/stas/.rvm/gems/ruby-2.7.4/bin/puma:23:in `load'
	10: from /home/stas/.rvm/gems/ruby-2.7.4/gems/puma-5.6.4/bin/puma:8:in `<top (required)>'
	 9: from /home/stas/.rvm/gems/ruby-2.7.4/gems/puma-5.6.4/bin/puma:8:in `new'
	 8: from /home/stas/.rvm/gems/ruby-2.7.4/gems/puma-5.6.4/lib/puma/cli.rb:72:in `initialize'
	 7: from /home/stas/.rvm/gems/ruby-2.7.4/gems/puma-5.6.4/lib/puma/cli.rb:72:in `new'
	 6: from /home/stas/.rvm/gems/ruby-2.7.4/gems/puma-5.6.4/lib/puma/launcher.rb:60:in `initialize'
	 5: from /home/stas/.rvm/gems/ruby-2.7.4/gems/puma-5.6.4/lib/puma/configuration.rb:219:in `load'
	 4: from /home/stas/.rvm/gems/ruby-2.7.4/gems/puma-5.6.4/lib/puma/configuration.rb:219:in `each'
	 3: from /home/stas/.rvm/gems/ruby-2.7.4/gems/puma-5.6.4/lib/puma/configuration.rb:219:in `block in load'
	 2: from /home/stas/.rvm/gems/ruby-2.7.4/gems/puma-5.6.4/lib/puma/dsl.rb:83:in `_load_from'
	 1: from /home/stas/.rvm/gems/ruby-2.7.4/gems/puma-5.6.4/lib/puma/dsl.rb:83:in `instance_eval'
scripts/puma.rb:9:in `_load_from': undefined local variable or method `daemonize' for #<Puma::DSL:0x00005592d6f2c858> (NameError)
```
