### PR TITLE
readme.md: add a section about generating docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ This will start a daemonized process, you can stop the server with:
 bundle exec rake server:stop
 ```
 
+### Generate documentation
+To generate stdlib docs, you would need to run the following:
+
+```sh
+rake stdlib:install SOURCE="$HOME/.rvm/rubies/ruby-3.1.2" VERSION="3.1.2"
+```
+
 ### Running With Docker
 
 If you have Docker installed, you can get started using `docker-compose`:


### PR DESCRIPTION
I got a bit stuck, while figuring out how to generate stdlib docs, so decided to write this down for future generations to ease onboarding into a project.

Hopefully, you'll find this useful as well.