### PR TITLE
Remove pagy due to removed support for Rails in v43.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,6 @@ end
 gem "version_sorter"
 gem "skylight", require: false
 gem "net-http-persistent", "~> 4.0"
-gem "pagy"
 gem "deep_merge", require: "deep_merge/rails_compat"
 gem "syntax"
 gem "yard", github: "lsegal/yard", branch: "main"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,9 +234,6 @@ GEM
     nokogiri (1.18.10-x86_64-linux-musl)
       racc (~> 1.4)
     ostruct (0.6.1)
-    pagy (43.2.0)
-      json
-      yaml
     parallel (1.27.0)
     parser (3.3.8.0)
       ast (~> 2.4.1)
@@ -425,7 +422,6 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yaml (0.4.0)
     yard-kramdown (0.0.1)
     yard-rails (0.3.0)
       yard
@@ -461,7 +457,6 @@ DEPENDENCIES
   mission_control-jobs
   net-http-persistent (~> 4.0)
   newrelic_rpm (~> 9.24)
-  pagy
   pg (~> 1.6)
   propshaft
   puma (>= 5.0)

--- a/app/controllers/concerns/pageable.rb
+++ b/app/controllers/concerns/pageable.rb
@@ -1,16 +1,15 @@
 module Pageable
   extend ActiveSupport::Concern
 
-  Pagy.options[:limit] = 100
+  PAGE_SIZE = 100
 
   included do
-    include Pagy::Method
-
     before_action :set_pagination
   end
 
   def set_pagination
     @page = params[:page]&.to_i || 1
-    @pagy, @collection = pagy(@collection, page: @page)
+    @total_pages = (@collection.except(:select).count / PAGE_SIZE.to_f).ceil
+    @collection = @collection.offset((@page - 1) * PAGE_SIZE).limit(PAGE_SIZE)
   end
 end

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -1,4 +1,4 @@
-<% if @pagy.pages > 1 %>
+<% if @total_pages > 1 %>
   <div class="tabbed-links numeric">
     Page:
     <% if @search %>
@@ -11,15 +11,15 @@
         <a href="<%= page_prefix %>1">1</a>
         ...
       <% end %>
-      <% next if page < 1 || page >= @pagy.pages %>
+      <% next if page < 1 || page > @total_pages %>
       <% if page == @page %>
         <span class="selected"><%= page %></span>
       <% else %>
         <a href="<%= page_prefix %><%= page %>"><%= page %></a>
       <% end %>
-      <% if page == @page + 9 && page < @pagy.pages %>
+      <% if page == @page + 9 && page < @total_pages %>
         ...
-        <a href="<%= page_prefix %><%= @pagy.pages - 1 %>"><%= @pagy.pages - 1 %></a>
+        <a href="<%= page_prefix %><%= @total_pages %>"><%= @total_pages %></a>
       <% end %>
     <% end %>
   </div>

--- a/app/views/shared/library_list.html.erb
+++ b/app/views/shared/library_list.html.erb
@@ -11,7 +11,7 @@
   <% end %>
 </h2>
 <%= render "shared/alpha_index" if @has_alpha_index %>
-<%= render "shared/pagination" if @pagy %>
+<%= render "shared/pagination" if @total_pages %>
 <% if @exact_match %>
   <h3>Exact match</h3>
   <div class="libraries">
@@ -25,4 +25,4 @@
   <% end %>
   <%= render partial: "shared/library", collection: @collection %>
 </div>
-<%= render "shared/pagination" if @pagy %>
+<%= render "shared/pagination" if @total_pages %>


### PR DESCRIPTION
pagy v43 removed out of the box support for standard Rails param routing which means we must now use workarounds to implement proper pagination with path based routes. This as seen as an unnecessary maintenance burden and isn't recommended by the project maintainer. Given the uncertainty of future support for Rails, it's not worth continuing to use pagy. See ddnexus/pagy#846

The good news is that pagy is easily replaceable and does not seem to be doing very much for our use case, so we can just use out of the box Rails methods.